### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ ADD paasmetric_normalization.json /cpr
 EXPOSE 8080
 
 ENTRYPOINT [ "java", "-jar", "CloudProviderRanker-jar-with-dependencies.jar" ]
-CMD [ "sla_priorities.json", "paasmetric_normalization.json", "8080" ]
+CMD [ "sla_priorities.json", "paasmetric_normalization.json" ]


### PR DESCRIPTION
The port 8080 is already used by default.

Signed-off-by: Fabrizio Chiarello <fabrizio.chiarello@pd.infn.it>