### PR TITLE
Set path to OWASP report (using 1.3.6 pipeline library)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/groovy
 
-@Library(['github.com/indigo-dc/jenkins-pipeline-library@1.3.1']) _
+@Library(['github.com/indigo-dc/jenkins-pipeline-library@1.3.6']) _
 
 pipeline {
     agent {
@@ -74,7 +74,7 @@ pipeline {
             }
             post {
                 always {
-                    OWASPDependencyCheckPublish()
+                    OWASPDependencyCheckPublish(report='**/dependency-check-report.xml')
                     HTMLReport(
                         "$WORKSPACE/CloudProviderRanker/src",
                         'dependency-check-report.html',


### PR DESCRIPTION
Jenkins pipeline was failing to publish OWASP report since the pattern used by default matched irrelevant files within the "src/" directory. The pattern has been set as a parameter in jenkins-pipeline-library version 1.3.6 and the OWASP check in the current Jenkinsfile now points to the appropriate file